### PR TITLE
Use fmt.Errorf for wrapping errors

### DIFF
--- a/application/server/slack.go
+++ b/application/server/slack.go
@@ -2,13 +2,13 @@ package server
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/url"
 	"strings"
 
 	"github.com/gin-gonic/gin"
-	"github.com/pkg/errors"
 	"github.com/slack-go/slack"
 )
 
@@ -16,7 +16,7 @@ func (e *engine) HandleSlackEvent(c *gin.Context) {
 	verifier, err := slack.NewSecretsVerifier(c.Request.Header, e.Environment.SlackAppSecret)
 	if err != nil {
 		c.Status(http.StatusUnauthorized)
-		c.Error(errors.Wrap(err, "failed to verify secret"))
+		c.Error(fmt.Errorf("failed to verify secret: %w", err))
 		return
 	}
 
@@ -26,14 +26,14 @@ func (e *engine) HandleSlackEvent(c *gin.Context) {
 	err = verifier.Ensure()
 	if err != nil {
 		c.Status(http.StatusUnauthorized)
-		c.Error(errors.Wrap(err, "failed to validate request"))
+		c.Error(fmt.Errorf("failed to validate request: %w", err))
 		return
 	}
 
 	values, err := url.ParseQuery(builder.String())
 	if err != nil {
 		c.Status(http.StatusBadRequest)
-		c.Error(errors.Wrap(err, "failed to parse request body"))
+		c.Error(fmt.Errorf("failed to parse request body: %w", err))
 		return
 	}
 
@@ -41,7 +41,7 @@ func (e *engine) HandleSlackEvent(c *gin.Context) {
 	err = json.Unmarshal([]byte(values.Get("payload")), &interaction)
 	if err != nil {
 		c.Status(http.StatusBadRequest)
-		c.Error(errors.Wrap(err, "failed to parse interaction"))
+		c.Error(fmt.Errorf("failed to parse interaction: %w", err))
 		return
 	}
 
@@ -50,22 +50,22 @@ func (e *engine) HandleSlackEvent(c *gin.Context) {
 			result, err := e.ActionService.Execute(action.Value)
 			if err != nil {
 				if result != nil {
-					c.Error(errors.Wrap(err, "failed to execute command"))
+					c.Error(fmt.Errorf("failed to execute command: %w", err))
 
 					err = e.InteractionService.Fail(*action, interaction, result, err)
 					if err != nil {
-						c.Error(errors.Wrap(err, "failed to respond to interaction"))
+						c.Error(fmt.Errorf("failed to respond to interaction: %w", err))
 					}
 					return
 				}
 
-				c.Error(errors.Wrap(err, "failed to execute action"))
+				c.Error(fmt.Errorf("failed to execute action: %w", err))
 				return
 			}
 
 			err = e.InteractionService.Respond(*action, interaction)
 			if err != nil {
-				c.Error(errors.Wrap(err, "failed to respond to interaction"))
+				c.Error(fmt.Errorf("failed to respond to interaction: %w", err))
 			}
 		}
 	}()

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/golang/protobuf v1.3.5 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.1 // indirect
-	github.com/pkg/errors v0.9.1
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/slack-go/slack v0.6.6
 	golang.org/x/crypto v0.0.0-20200403201458-baeed622b8d8
 	golang.org/x/sys v0.0.0-20200406113430-c6e801f48ba2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,6 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/gin-contrib/sse v0.1.0 h1:Y/yl/+YNO8GZSjAhjMsSuLt29uWRFHdHYUb5lYOV9qE=
 github.com/gin-contrib/sse v0.1.0/go.mod h1:RHrZQHXnP2xjPF+u1gW/2HnVO7nvIa9PG3Gm+fLHvGI=
-github.com/gin-gonic/gin v1.6.2 h1:88crIK23zO6TqlQBt+f9FrPJNKm9ZEr7qjp9vl/d5TM=
-github.com/gin-gonic/gin v1.6.2/go.mod h1:75u5sXoLsGZoRN5Sgbi1eraJ4GU3++wFwWzhwvtwp4M=
 github.com/gin-gonic/gin v1.6.3 h1:ahKqKTFpO5KTPHxWZjEdPScmYaGtLo8Y4DMHoEsnp14=
 github.com/gin-gonic/gin v1.6.3/go.mod h1:75u5sXoLsGZoRN5Sgbi1eraJ4GU3++wFwWzhwvtwp4M=
 github.com/go-playground/assert/v2 v2.0.1 h1:MsBgLAaY856+nPRTKrp3/OZK38U/wa0CcBYNjji3q3A=
@@ -22,8 +20,6 @@ github.com/golang/protobuf v1.3.3/go.mod h1:vzj43D7+SQXF/4pzW/hwtAqwc6iTitCiVSaW
 github.com/golang/protobuf v1.3.5 h1:F768QJ1E9tib+q5Sc8MkdJi1RxLTbRcTf8LJV56aRls=
 github.com/golang/protobuf v1.3.5/go.mod h1:6O5/vntMXwX2lRkT1hjjk0nAC1IDOTvTlVgjlRvqsdk=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
-github.com/gorilla/websocket v1.2.0 h1:VJtLvh6VQym50czpZzx07z/kw9EgAxI3x1ZB8taTMQQ=
-github.com/gorilla/websocket v1.2.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/json-iterator/go v1.1.9 h1:9yzud/Ht36ygwatGx56VwCZtlI/2AD15T1X2sjSuGns=
@@ -40,18 +36,11 @@ github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742 h1:Esafd1046DLD
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.1 h1:9f412s+6RmYXLWZSEzVVgPGK7C2PphHj5RJrvfx9AWI=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
-github.com/nlopes/slack v0.6.0/go.mod h1:JzQ9m3PMAqcpeCam7UaHSuBuupz7CmpjehYMayT6YOk=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/slack-go/slack v0.6.3 h1:qU037g8gQ71EuH6S9zYKnvYrEUj0fLFH4HFekFqBoRU=
-github.com/slack-go/slack v0.6.3/go.mod h1:HE4RwNe7YpOg/F0vqo5PwXH3Hki31TplTvKRW9dGGaw=
-github.com/slack-go/slack v0.6.4 h1:cxOqFgM5RW6mdEyDqAJutFk3qiORK9oHRKi5bPqkY9o=
-github.com/slack-go/slack v0.6.4/go.mod h1:sGRjv3w+ERAUMMMbldHObQPBcNSyVB7KLKYfnwUFBfw=
-github.com/slack-go/slack v0.6.5 h1:IkDKtJ2IROJNoe3d6mW870/NRKvq2fhLB/Q5XmzWk00=
-github.com/slack-go/slack v0.6.5/go.mod h1:FGqNzJBmxIsZURAxh2a8D21AnOVvvXZvGligs4npPUM=
 github.com/slack-go/slack v0.6.6 h1:ln0fO794CudStSJEfhZ08Ok5JanMjvW6/k2xBuHqedU=
 github.com/slack-go/slack v0.6.6/go.mod h1:FGqNzJBmxIsZURAxh2a8D21AnOVvvXZvGligs4npPUM=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/infrastructure/client/slack.go
+++ b/infrastructure/client/slack.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/chitoku-k/slack-to-ssh/infrastructure/config"
 	"github.com/chitoku-k/slack-to-ssh/service"
-	"github.com/pkg/errors"
 	"github.com/slack-go/slack"
 )
 
@@ -31,7 +30,7 @@ func (sir *slackInteractionResponder) Execute(response service.SlackInteractionR
 	}
 
 	if action == nil {
-		return errors.New("failed to find suitable action: " + response.ActionName)
+		return fmt.Errorf("failed to find suitable action: %s", response.ActionName)
 	}
 
 	options := []slack.MsgOption{
@@ -61,5 +60,8 @@ func (sir *slackInteractionResponder) Execute(response service.SlackInteractionR
 		response.Message.Channel,
 		options...,
 	)
-	return errors.Wrap(err, "failed to send response")
+	if err != nil {
+		return fmt.Errorf("failed to send response: %w", err)
+	}
+	return nil
 }

--- a/main.go
+++ b/main.go
@@ -1,22 +1,23 @@
 package main
 
 import (
+	"fmt"
+
 	"github.com/chitoku-k/slack-to-ssh/application/server"
 	"github.com/chitoku-k/slack-to-ssh/infrastructure/client"
 	"github.com/chitoku-k/slack-to-ssh/infrastructure/config"
 	"github.com/chitoku-k/slack-to-ssh/service"
-	"github.com/pkg/errors"
 )
 
 func main() {
 	env, err := config.Get()
 	if err != nil {
-		panic(errors.Wrap(err, "failed to initialize config"))
+		panic(fmt.Errorf("failed to initialize config: %w", err))
 	}
 
 	shellActionExecutor, err := client.NewShellActionExecutor(env)
 	if err != nil {
-		panic(errors.Wrap(err, "faled to initialize ssh config"))
+		panic(fmt.Errorf("faled to initialize ssh config: %w", err))
 	}
 
 	action := service.NewActionService(shellActionExecutor)


### PR DESCRIPTION
Refactor error wrappings preferring `fmt.Errorf()` + `%w` to `github.com/pkg/errors`.