### PR TITLE
Publish `latest` images on push to master branch

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -37,7 +37,6 @@ jobs:
           cache-to: type=gha,mode=max
           push: true
           tags: |
-            ghcr.io/chitoku-k/slack-to-ssh:latest
             ghcr.io/chitoku-k/slack-to-ssh:${{ github.ref_name }}
   deploy:
     name: Deploy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,12 +18,22 @@ jobs:
         uses: actions/checkout@v4
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+      - name: Log into Container Registry
+        if: ${{ github.ref_name == 'master' }}
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build
         uses: docker/build-push-action@v6
         with:
           context: .
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          push: ${{ github.ref_name == 'master' }}
+          tags: |
+            ghcr.io/chitoku-k/slack-to-ssh:latest
   test:
     name: Test
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR changes CI/CD to publish `latest` images on push to master branch. The `latest` tag is no longer stable.